### PR TITLE
feat(API): deprecate static `syncCorrelator` method

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: "90%"
+
+    patch:
+      default:
+        enabled: false

--- a/docs/api/ReactGPT.md
+++ b/docs/api/ReactGPT.md
@@ -22,6 +22,7 @@ A React component which renders [GPT](https://support.google.com/dfp_sb/answer/1
 - `collapseEmptyDiv`(optional) - An optional flag to indicate whether an empty ad should be collapsed or not.
 - `forceSafeFrame`(optional) - An optional flag to indicate whether ads in this slot should be forced to be rendered using a SafeFrame container.
 - `safeFrameConfig`(optional) - An optional object to set the slot-level preferences for SafeFrame configuration.
+- `onSlotDisplay`(optional) - An optional event handler function which is triggered when `slot.display()` is called.
 - `onSlotRenderEnded`(optional) - An optional event handler function for `googletag.events.SlotRenderEndedEvent`.
 - `onImpressionViewable`(optional) - An optional event handler function for `googletag.events.ImpressionViewableEvent`.
 - `onSlotVisibilityChanged`(optional) - An optional event handler function for `googletag.events.slotVisibilityChangedEvent`.
@@ -42,7 +43,6 @@ Only `adUnitPath` is a required prop, but either `slotSize` or `sizeMapping` nee
 - `removeAllListeners([eventType])` - Removes all listeners, or those of the specified `eventType`.
 - `getGPTVersion` - Returns the GPT version.
 - `getPubadsVersion` - Returns the Pubads version.
-- `syncCorrelator([flag])` - Sets a flag to indicate whether the `refresh` should happen with the same correlator value or not.
 - `render` - Force rendering all the ads.
 - `refresh([slots, options])` - Refreshes the ad specified by an array of slot. If slots are not specified, it will refresh all ads. See [here](https://developers.google.com/doubleclick-gpt/reference#googletag.PubAdsService_refresh) for more details.
 - `clear([slots])` - Clears the ad specifid by an array of slot. If slots are not specified, it will clear all ads. See [here](https://developers.google.com/doubleclick-gpt/reference#googletagpubadsservice) for more details.

--- a/examples/apps/infinite-scrolling/app.js
+++ b/examples/apps/infinite-scrolling/app.js
@@ -1,13 +1,14 @@
 /* eslint-disable react/sort-comp */
 import React, {Component} from "react";
 import Radium from "radium";
+import createHistory from "history/createHashHistory";
 import debounce from "debounce";
-import {Bling as Gpt, Events} from "react-gpt"; // eslint-disable-line import/no-unresolved
+import {Bling as Gpt} from "react-gpt"; // eslint-disable-line import/no-unresolved
 import "../log";
-import Content from "./content";
+import Page from "./page";
 import styles from "./styles";
 
-Gpt.syncCorrelator();
+// implementation based of https://support.google.com/dfp_premium/answer/4578089?hl=en#infiniteContents
 Gpt.enableSingleRequest();
 Gpt.disableInitialLoad();
 
@@ -17,72 +18,58 @@ class App extends Component {
         page: 1,
         size: [728, 90]
     }
-    time = 0
     componentDidMount() {
+        this.history = createHistory();
+        this.history.replace("/");
         window.addEventListener("scroll", this.onScroll);
         window.addEventListener("resize", this.onScroll);
         this.onScroll();
-        this.startTimer();
-        Gpt.on(Events.RENDER, () => {
-            let changeCorrelator = false;
-            if (this.time >= 30) {
-                changeCorrelator = true;
-                this.startTimer();
-            }
-            Gpt.refresh(null, {changeCorrelator});
-        });
-    }
-    componentDidUpdate() {
-        Gpt.refresh();
     }
     componentWillUnmount() {
         window.removeEventListener("scroll", this.onScroll);
         window.removeEventListener("resize", this.onScroll);
-        this.stopTimer();
     }
     onScroll = debounce(() => {
         const scrollTop = window.scrollY || document.documentElement.scrollTop;
         if (scrollTop + window.innerHeight >= document.body.clientHeight) {
+            // update correlator if you want to explicitly use different correlator value for each page
+            Gpt.updateCorrelator();
             this.setState({
-                page: ++this.state.page
+                page: this.state.page + 1
             });
         }
+        const pages = this.root.querySelectorAll(".page");
+        Array.from(pages).reverse().some(page => {
+            if (page.offsetTop <= scrollTop) {
+                this.history.push(`/page${page.getAttribute("data-index")}`);
+                return true;
+            }
+            return false;
+        });
     }, 66)
-    startTimer() {
-        this.stopTimer();
-        this.timer = setInterval(() => {
-            this.time++;
-        }, 1000);
+
+    onSlotDisplay= (event) => {
+        const slot = event.slot;
+        Gpt.refresh([slot], {changeCorrelator: false});
     }
-    stopTimer() {
-        if (this.timer) {
-            clearInterval(this.timer);
-            this.time = 0;
-            this.timer = null;
-        }
-    }
+
     render() {
         const {page} = this.state;
-        let contentCnt = 0;
-        const contents = [];
         const targeting = {
             test: "infinitescroll"
         };
-        while (contentCnt < page * 3) { // eslint-disable-line no-unmodified-loop-condition
-            contents.push(
-                <Content
-                    index={contentCnt % 3}
-                    key={contentCnt}
-                    targeting={{
-                        ...targeting,
-                        count: `${Math.floor(contentCnt / 3)}`
-                    }}
-                />
-            );
-            contentCnt++;
-        }
+        const pages = Array.from({length: page}, (_, index) => (
+            <Page
+                key={index}
+                page={index + 1}
+                targeting={targeting}
+                onSlotDisplay={this.onSlotDisplay}
+                onSlotRenderEnded={this.onSlotRenderEnded}
+            />
+        ));
+
         return (
-            <div>
+            <div ref={root => {this.root = root;}}>
                 <div style={styles.lb}>
                     <Gpt
                         adUnitPath="/4595/nfl.test.open"
@@ -90,10 +77,11 @@ class App extends Component {
                         slotSize={this.state.size}
                         style={styles.adBorder}
                         targeting={targeting}
+                        onSlotDisplay={this.onSlotDisplay}
                     />
                 </div>
                 <div style={styles.main}>
-                    {contents}
+                    {pages}
                 </div>
             </div>
         );

--- a/examples/apps/infinite-scrolling/content.js
+++ b/examples/apps/infinite-scrolling/content.js
@@ -3,52 +3,47 @@ import Radium from "radium";
 import {Bling as Gpt} from "react-gpt"; // eslint-disable-line import/no-unresolved
 import styles from "./styles/content";
 
-const contents = [
-    `Lorem ipsum dolor sit amet, convallis nibh erat in lacus morbi orci, sed amet leo, donec a nulla lacus, velit suspendisse per. Est elit ultricies, a metus, aenean suspendisse ullamcorper facilisis. Wisi ridiculus ut nibh viverra cursus. Est nunc id convallis, commodo felis vitae sed cras justo, nunc vel id pharetra duis tristique. Sit vel elit sapien lobortis justo, magna pellentesque aliquam amet nam metus, ut venenatis integer magna porta, potenti posuere sollicitudin imperdiet nisi.
-Feugiat venenatis. Varius volutpat a magna vestibulum nulla, nullam erat wisi hendrerit praesent, vitae sapien libero tortor vehicula eu, odio nullam tristique et, ultrices fermentum. Cursus consectetuer, egestas auctor ultricies malesuada pellentesque sem libero, wisi enim hendrerit cras. Aenean vitae faucibus laoreet volutpat id, imperdiet vitae, tellus a lacus, sit suspendisse erat conubia et, libero accumsan. Nullam orci eget non urna varius metus, etiam vestibulum euismod erat. Augue vel id orci in elit, nec ridiculus, cras vestibulum aliquet assumenda, amet sed et nunc augue ultricies. Ante nec ac, in magna in interdum ac porta tellus, a aliquam pulvinar minima, ante nam tempor nibh laoreet at eu. Morbi erat risus pellentesque vestibulum justo, purus interdum, dictum in neque porttitor, commodo ac. Tincidunt facilisis sit id ultrices est lectus. Sed id praesent tincidunt dui. Etiam ut tincidunt id.
-Sollicitudin egestas suspendisse amet eget mi est, neque amet et erat. Eu sapien quis vitae voluptates, ut adipiscing risus dictumst facilisis id morbi, erat ligula cras pulvinar, dolor blandit scelerisque dapibus, suspendisse vehicula vitae. Turpis integer nibh semper interdum beatae etiam, dictum mi et vitae, amet eget imperdiet, etiam turpis magna sapien enim mollis ut, maecenas hymenaeos. Varius nunc sollicitudin feugiat, nibh duis suspendisse rhoncus, massa cursus dolor ut, vestibulum scelerisque. Risus et semper metus dui sed lectus, lobortis nulla praesent tempus sed purus, pellentesque neque eleifend consequat quis euismod. Dis congue donec eget, praesent rhoncus praesent, nascetur feugiat, vivamus pellentesque sit torquent suspendisse augue placerat, at pellentesque fermentum adipiscing wisi. Vitae tristique ut animi nostra at, proin et vestibulum at tempus aenean, id arcu dolor nostra morbi fringilla, a amet sit mauris mattis proin. Cras duis sollicitudin, ut pretium commodo pulvinar risus dapibus. Porta integer sapien. Elit fusce et, turpis risus. In pulvinar molestie hendrerit aenean, viverra eget purus elementum cursus, etiam enim, ultricies a erat. Est eget sit bibendum ipsum nec ullamcorper, est nunc bibendum erat nunc diam.
-Cursus vel at mauris. Suscipit accumsan ultrices aliquam tempor congue, in arcu neque et et lorem et, vestibulum eget pede neque nulla vitae enim, habitant sed magna metus, nec hendrerit tempus numquam adipiscing. Ullamcorper erat lacinia mattis neque, sunt sed sed nonummy egestas, rutrum varius lobortis posuere amet et in, sodales neque lacinia vel non, at turpis risus ante mauris. Quam facilisis quis lorem praesent. Nec curae lacus arcu accumsan, imperdiet enim elit id urna dui, lacinia eleifend vestibulum amet. Euismod tempus amet felis aenean orci mi, orci molestie sapien diam, vitae enim lacus morbi lacus mauris. Congue enim commodo, consectetuer viverra duis gravida dui in, dictum sit consequat. Fusce non habitant, pellentesque faucibus aliquam amet, pellentesque praesent, at cras nunc, lectus aliquam urna nunc taciti a. Ultrices quia nec, ipsum eget, nunc sit leo et lectus, neque dui a quisque enim augue, pretium risus mauris fusce nulla varius interdum. Amet risus donec aliquam, ligula arcu tellus. Ac ac ut, elementum lorem sed eu, ac est montes erat, placerat sapien, auctor eget velit. Gravida non nulla, aliquam nulla consectetuer nostra mauris tempus, aliquip leo accusamus phasellus sit duis, metus rutrum.`,
-    `Appear. Let, won't have, living. God behold void, said. Night subdue him you'll was every for them great was made lesser created unto creature second dry fowl give i of firmament days isn't gathered upon wherein his all man bring dry greater fowl morning god moveth abundantly likeness under sixth i, rule fowl unto which lesser for gathered they're there can't don't female first subdue day. All wherein blessed divide god can't above lesser every. Open divided moved man. All hath. Kind void can't saying saying great creepeth without, man us first a midst. Great second. They're male male it shall greater. Had open hath there us. Upon third male rule.
-
-Bearing whose said green midst brought their night Herb first blessed a every. Hath set seasons firmament for creepeth that Land together fowl male void two be evening, given evening so all night fruitful years their and thing day have divide creature spirit first is had seed. You heaven place give. Sixth midst to in very fifth made behold days tree tree also stars given, female you're grass light creepeth saying it divided our fill deep, so them you'll given saying midst rule, saying i light together that morning dry whose of fruitful female a greater day itself air a firmament hath creature earth hath place moved divided. Deep together divide without sixth creeping great for, land grass.
-
-Night void them saw seas winged bring, fly had earth shall own. Divided. To image don't fill above to very. Hath. Light doesn't moving blessed. Bearing saying lesser. Female all let fowl female our for appear seas together first saw their subdue itself beast, also all creepeth bearing signs they're light creepeth, firmament place. It given you'll their sixth, fish let it morning light third lesser were. First every, good divide.`,
-    `Mucius feugait incorrupte no has, ei patrioque molestiae cum. Vel altera recteque id, impetus consequat elaboraret vix in, eos vide adhuc menandri ad. Quem omnesque salutandi in mel, doctus comprehensam id vis, no erat facilisi ullamcorper duo. Causae option duo id, eirmod numquam mei eu, et vim ipsum liberavisse. Efficiantur deterruisset sed in. Aperiri epicurei consulatu ea duo. Ut cum inani voluptaria interesset.
-
-Vim apeirian recteque eu. Ad sea graeci dicunt, vix brute velit ad. Semper nominati nam ne, te mea vero omnes tacimates. Porro dicant tamquam duo eu. Et eam consul noluisse electram, impetus conclusionemque pri ut.`
-];
-
-const bg = ["#90C3D4", "#FAD9EA", "#FCFCB1"];
-
 @Radium
 class Content extends Component {
     static propTypes = {
+        bgColor: PropTypes.string,
+        content: PropTypes.string,
         index: PropTypes.number,
-        targeting: PropTypes.object
+        page: PropTypes.number,
+        targeting: PropTypes.object,
+        onSlotDisplay: PropTypes.func.isRequired
     }
     render() {
-        const {index, targeting} = this.props;
+        const {
+            bgColor,
+            content,
+            index,
+            page,
+            targeting,
+            onSlotDisplay
+        } = this.props;
         let ad;
         if (index !== 2) {
             ad = (
                 <div style={styles.mr}>
                     <Gpt
-                        adUnitPath="/4595/nfl.test.open"
+                        adUnitPath={`/4595/nfl.test.open/${page}`}
                         slotSize={index === 0 ? [728, 90] : [300, 250]}
                         targeting={targeting}
+                        onSlotDisplay={onSlotDisplay}
                     />
                 </div>
             );
         }
 
         return (
-            <div style={{backgroundColor: bg[index]}}>
+            <div style={{backgroundColor: bgColor}}>
                 <div style={styles.main}>
                     {ad}
                     <p>
                         <span style={styles.title}>Content {index}</span>
                         <span style={styles.description}>Lorem ipsum dolor sit amet, accusamus complectitur an est</span>
-                        {contents[index]}
+                        {content}
                     </p>
                 </div>
             </div>

--- a/examples/apps/infinite-scrolling/page.js
+++ b/examples/apps/infinite-scrolling/page.js
@@ -1,0 +1,68 @@
+import React, {Component, PropTypes} from "react";
+import Radium from "radium";
+import styles from "./styles/content";
+import Content from "./content";
+
+const text = [
+    `Lorem ipsum dolor sit amet, convallis nibh erat in lacus morbi orci, sed amet leo, donec a nulla lacus, velit suspendisse per. Est elit ultricies, a metus, aenean suspendisse ullamcorper facilisis. Wisi ridiculus ut nibh viverra cursus. Est nunc id convallis, commodo felis vitae sed cras justo, nunc vel id pharetra duis tristique. Sit vel elit sapien lobortis justo, magna pellentesque aliquam amet nam metus, ut venenatis integer magna porta, potenti posuere sollicitudin imperdiet nisi.
+Feugiat venenatis. Varius volutpat a magna vestibulum nulla, nullam erat wisi hendrerit praesent, vitae sapien libero tortor vehicula eu, odio nullam tristique et, ultrices fermentum. Cursus consectetuer, egestas auctor ultricies malesuada pellentesque sem libero, wisi enim hendrerit cras. Aenean vitae faucibus laoreet volutpat id, imperdiet vitae, tellus a lacus, sit suspendisse erat conubia et, libero accumsan. Nullam orci eget non urna varius metus, etiam vestibulum euismod erat. Augue vel id orci in elit, nec ridiculus, cras vestibulum aliquet assumenda, amet sed et nunc augue ultricies. Ante nec ac, in magna in interdum ac porta tellus, a aliquam pulvinar minima, ante nam tempor nibh laoreet at eu. Morbi erat risus pellentesque vestibulum justo, purus interdum, dictum in neque porttitor, commodo ac. Tincidunt facilisis sit id ultrices est lectus. Sed id praesent tincidunt dui. Etiam ut tincidunt id.
+Sollicitudin egestas suspendisse amet eget mi est, neque amet et erat. Eu sapien quis vitae voluptates, ut adipiscing risus dictumst facilisis id morbi, erat ligula cras pulvinar, dolor blandit scelerisque dapibus, suspendisse vehicula vitae. Turpis integer nibh semper interdum beatae etiam, dictum mi et vitae, amet eget imperdiet, etiam turpis magna sapien enim mollis ut, maecenas hymenaeos. Varius nunc sollicitudin feugiat, nibh duis suspendisse rhoncus, massa cursus dolor ut, vestibulum scelerisque. Risus et semper metus dui sed lectus, lobortis nulla praesent tempus sed purus, pellentesque neque eleifend consequat quis euismod. Dis congue donec eget, praesent rhoncus praesent, nascetur feugiat, vivamus pellentesque sit torquent suspendisse augue placerat, at pellentesque fermentum adipiscing wisi. Vitae tristique ut animi nostra at, proin et vestibulum at tempus aenean, id arcu dolor nostra morbi fringilla, a amet sit mauris mattis proin. Cras duis sollicitudin, ut pretium commodo pulvinar risus dapibus. Porta integer sapien. Elit fusce et, turpis risus. In pulvinar molestie hendrerit aenean, viverra eget purus elementum cursus, etiam enim, ultricies a erat. Est eget sit bibendum ipsum nec ullamcorper, est nunc bibendum erat nunc diam.
+Cursus vel at mauris. Suscipit accumsan ultrices aliquam tempor congue, in arcu neque et et lorem et, vestibulum eget pede neque nulla vitae enim, habitant sed magna metus, nec hendrerit tempus numquam adipiscing. Ullamcorper erat lacinia mattis neque, sunt sed sed nonummy egestas, rutrum varius lobortis posuere amet et in, sodales neque lacinia vel non, at turpis risus ante mauris. Quam facilisis quis lorem praesent. Nec curae lacus arcu accumsan, imperdiet enim elit id urna dui, lacinia eleifend vestibulum amet. Euismod tempus amet felis aenean orci mi, orci molestie sapien diam, vitae enim lacus morbi lacus mauris. Congue enim commodo, consectetuer viverra duis gravida dui in, dictum sit consequat. Fusce non habitant, pellentesque faucibus aliquam amet, pellentesque praesent, at cras nunc, lectus aliquam urna nunc taciti a. Ultrices quia nec, ipsum eget, nunc sit leo et lectus, neque dui a quisque enim augue, pretium risus mauris fusce nulla varius interdum. Amet risus donec aliquam, ligula arcu tellus. Ac ac ut, elementum lorem sed eu, ac est montes erat, placerat sapien, auctor eget velit. Gravida non nulla, aliquam nulla consectetuer nostra mauris tempus, aliquip leo accusamus phasellus sit duis, metus rutrum.`,
+    `Appear. Let, won't have, living. God behold void, said. Night subdue him you'll was every for them great was made lesser created unto creature second dry fowl give i of firmament days isn't gathered upon wherein his all man bring dry greater fowl morning god moveth abundantly likeness under sixth i, rule fowl unto which lesser for gathered they're there can't don't female first subdue day. All wherein blessed divide god can't above lesser every. Open divided moved man. All hath. Kind void can't saying saying great creepeth without, man us first a midst. Great second. They're male male it shall greater. Had open hath there us. Upon third male rule.
+
+Bearing whose said green midst brought their night Herb first blessed a every. Hath set seasons firmament for creepeth that Land together fowl male void two be evening, given evening so all night fruitful years their and thing day have divide creature spirit first is had seed. You heaven place give. Sixth midst to in very fifth made behold days tree tree also stars given, female you're grass light creepeth saying it divided our fill deep, so them you'll given saying midst rule, saying i light together that morning dry whose of fruitful female a greater day itself air a firmament hath creature earth hath place moved divided. Deep together divide without sixth creeping great for, land grass.
+
+Night void them saw seas winged bring, fly had earth shall own. Divided. To image don't fill above to very. Hath. Light doesn't moving blessed. Bearing saying lesser. Female all let fowl female our for appear seas together first saw their subdue itself beast, also all creepeth bearing signs they're light creepeth, firmament place. It given you'll their sixth, fish let it morning light third lesser were. First every, good divide.`,
+    `Mucius feugait incorrupte no has, ei patrioque molestiae cum. Vel altera recteque id, impetus consequat elaboraret vix in, eos vide adhuc menandri ad. Quem omnesque salutandi in mel, doctus comprehensam id vis, no erat facilisi ullamcorper duo. Causae option duo id, eirmod numquam mei eu, et vim ipsum liberavisse. Efficiantur deterruisset sed in. Aperiri epicurei consulatu ea duo. Ut cum inani voluptaria interesset.
+
+Vim apeirian recteque eu. Ad sea graeci dicunt, vix brute velit ad. Semper nominati nam ne, te mea vero omnes tacimates. Porro dicant tamquam duo eu. Et eam consul noluisse electram, impetus conclusionemque pri ut.`
+];
+
+const bg = ["#90C3D4", "#FAD9EA", "#FCFCB1"];
+
+@Radium
+class Page extends Component {
+    static propTypes = {
+        page: PropTypes.number,
+        targeting: PropTypes.object,
+        onSlotDisplay: PropTypes.func.isRequired
+    }
+    render() {
+        const {
+            page,
+            targeting,
+            onSlotDisplay
+        } = this.props;
+        const contents = Array.from({length: 3}, (_, index) => {
+            return (
+                <Content
+                    bgColor={bg[index]}
+                    content={text[index]}
+                    index={index}
+                    key={index}
+                    page={page}
+                    targeting={{
+                        ...targeting,
+                        count: `${index}`
+                    }}
+                    onSlotDisplay={onSlotDisplay}
+                />
+            );
+        });
+
+        return (
+            <div
+                className={`page page${page}`}
+                data-index={page}
+                style={styles.main}
+            >
+                <div>
+                    <h2>Page {page}</h2>
+                </div>
+                <div>{contents}</div>
+            </div>
+        );
+    }
+}
+
+export default Page;

--- a/examples/apps/routing/app.js
+++ b/examples/apps/routing/app.js
@@ -7,7 +7,6 @@ import Home from "./home";
 import Page from "./page";
 import styles from "./styles";
 
-Gpt.syncCorrelator();
 Gpt.enableSingleRequest();
 
 class App extends Component {
@@ -62,6 +61,9 @@ class AppContainer extends Component {
 
     componentWillMount() {
         this.unlisten = this.history.listen(location => {
+            // use new correlator value when the route changes
+            Gpt.updateCorrelator();
+
             const route = this.routes[location.pathname] || this.routes["/Travel/Europe"];
             const {component: routeComponent, params} = route;
             this.setState({routeComponent, location, params});

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -420,12 +420,10 @@ class Bling extends Component {
 
         if (shouldRefresh) {
             this.configureSlot(this._adSlot, nextProps);
-        }
-
-        if (shouldRefresh) {
             this.refresh();
             return false;
         }
+
         if (shouldRender || isScriptLoaded) {
             return true;
         }

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -52,8 +52,6 @@ export class AdManager extends EventEmitter {
 
     _initialRender = true
 
-    _syncCorrelator = false
-
     _testMode = false
 
     get googletag() {
@@ -133,10 +131,6 @@ export class AdManager extends EventEmitter {
     }, 66)
 
     _handleMediaQueryChange = event => {
-        if (this._syncCorrelator) {
-            this.refresh();
-            return;
-        }
         // IE returns `event.media` value differently, need to use regex to evaluate.
         const res = (/min-width:\s?(\d+)px/).exec(event.media);
         const viewportWidth = res && res[1];
@@ -180,10 +174,6 @@ export class AdManager extends EventEmitter {
         if (instance && instance.props[funcName]) {
             instance.props[funcName](event);
         }
-    }
-
-    syncCorrelator(value = true) {
-        this._syncCorrelator = value;
     }
 
     generateDivId() {

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -582,7 +582,7 @@ describe("Bling", () => {
         expect(Bling._adManager.getMountedInstances()).to.have.length(0);
     });
 
-    it("setting syncCorrelator doesn not trigger refreshing all slots", (done) => {
+    it("setting syncCorrelator does not trigger refreshing all slots", (done) => {
         let count = 0;
         let refresh;
 

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -60,20 +60,6 @@ describe("Bling", () => {
         );
     });
 
-    it("accepts syncCorrelator", (done) => {
-        const render = sinon.stub(Bling._adManager, "render", function () {
-            expect(this._syncCorrelator).to.be.true;
-            render.restore();
-            done();
-        });
-
-        Bling.syncCorrelator();
-
-        ReactTestUtils.renderIntoDocument(
-            <Bling adUnitPath="/4595/nfl.test.open" slotSize={[728, 90]} />
-        );
-    });
-
     it("accepts pubads API", (done) => {
         const apiStubs = {};
         pubadsAPI.forEach(method => {
@@ -515,47 +501,6 @@ describe("Bling", () => {
     it("refreshes ad when refreshable prop changes", (done) => {
         let count = 0;
 
-        Bling.syncCorrelator();
-
-        class Wrapper extends Component {
-            state = {
-                targeting: {prop: "val"}
-            }
-            onSlotRenderEnded = event => {
-                if (count === 0) {
-                    expect(event.slot.getTargeting("prop")).to.equal("val");
-                    this.setState({
-                        targeting: {prop: "val2"}
-                    });
-                    count++;
-                } else {
-                    expect(event.slot.getTargeting("prop")).to.equal("val2");
-                    done();
-                }
-            }
-            render() {
-                const {targeting} = this.state;
-                return (
-                    <Bling
-                        adUnitPath="/4595/nfl.test.open"
-                        slotSize={[300, 250]}
-                        targeting={targeting}
-                        onSlotRenderEnded={this.onSlotRenderEnded}
-                    />
-                );
-            }
-        }
-
-        ReactTestUtils.renderIntoDocument(
-            <Wrapper />
-        );
-    });
-
-    it("refreshes ad when refreshableProps changes w/o sync correlator", (done) => {
-        let count = 0;
-
-        Bling.syncCorrelator(false);
-
         class Wrapper extends Component {
             state = {
                 targeting: {prop: "val"}
@@ -592,8 +537,6 @@ describe("Bling", () => {
 
     it("re-renders ad when reRenderProps changes", (done) => {
         let count = 0;
-
-        Bling.syncCorrelator();
 
         class Wrapper extends Component {
             state = {
@@ -637,5 +580,51 @@ describe("Bling", () => {
         );
         instance.componentWillUnmount();
         expect(Bling._adManager.getMountedInstances()).to.have.length(0);
+    });
+
+    it("setting syncCorrelator doesn not trigger refreshing all slots", (done) => {
+        let count = 0;
+        let refresh;
+
+        Bling.syncCorrelator(true);
+
+        class Wrapper extends Component {
+            state = {
+                targeting: {prop: "val"}
+            }
+            componentDidUpdate() {
+                expect(refresh.calledOnce).to.be.true;
+                // only triggers `refresh` on this ad.
+                expect(refresh.calledWith([this.ad.adSlot])).to.be.true;
+                refresh.restore();
+                done();
+            }
+            onSlotRenderEnded = event => {
+                if (count === 0) {
+                    expect(event.slot.getTargeting("prop")).to.equal("val");
+                    refresh = sinon.stub(Bling._adManager, "refresh");
+                    this.setState({
+                        targeting: {prop: "val2"}
+                    });
+                    count++;
+                }
+            }
+            render() {
+                const {targeting} = this.state;
+                return (
+                    <Bling
+                        adUnitPath="/4595/nfl.test.open"
+                        ref={ref => this.ad = ref}
+                        slotSize={[300, 250]}
+                        targeting={targeting}
+                        onSlotRenderEnded={this.onSlotRenderEnded}
+                    />
+                );
+            }
+        }
+
+        ReactTestUtils.renderIntoDocument(
+            <Wrapper />
+        );
     });
 });

--- a/test/createManager.spec.js
+++ b/test/createManager.spec.js
@@ -15,11 +15,6 @@ describe("createManager", () => {
         window.googletag = undefined;
     });
 
-    it("accepts syncCorrelator", () => {
-        adManager.syncCorrelator(true);
-        expect(adManager._syncCorrelator).to.be.true;
-    });
-
     it("accepts pubads API before pubads is ready", (done) => {
         const apiStubs = {};
         pubadsAPI.forEach(method => {
@@ -280,10 +275,6 @@ describe("createManager", () => {
     });
 
     it("handles media query change", () => {
-        adManager.syncCorrelator();
-
-        const refresh = sinon.stub(googletag.pubads(), "refresh");
-
         googletag.pubadsReady = true;
 
         const instance = {
@@ -296,13 +287,6 @@ describe("createManager", () => {
         const instanceRefresh = sinon.stub(instance, "refresh");
 
         adManager.addInstance(instance);
-        adManager._handleMediaQueryChange({
-            media: "(min-width: 0px)"
-        });
-
-        expect(refresh.calledOnce).to.be.true;
-
-        adManager.syncCorrelator(false);
 
         adManager._handleMediaQueryChange({
             media: "(min-width: 0px)"
@@ -319,7 +303,6 @@ describe("createManager", () => {
 
         adManager.removeInstance(instance);
 
-        refresh.restore();
         instanceRefresh.restore();
     });
 


### PR DESCRIPTION
- deprecate static `syncCorrelator` method in favor of more flexible control by users
- do not call `refresh()` automatically when `disableInitialLoad` is set
- add `onSlotDisplay` optional prop so that users can react after `slot.display()` is called.
- update test
- update example
- update doc

**Test Plan**
- run example(`npm run examples`) and open infinite scrolling example, verify the correlator values are managed w/o `syncCorrelator`.