### PR TITLE
Fix Empty adSlot Object Caused by Ad Blocker

### DIFF
--- a/src/Bling.js
+++ b/src/Bling.js
@@ -668,7 +668,7 @@ class Bling extends Component {
 
     clear() {
         const adSlot = this._adSlot;
-        if (adSlot) {
+        if (adSlot && adSlot.hasOwnProperty("getServices")) {
             // googletag.ContentService doesn't clear content
             const services = adSlot.getServices();
             if (this._divId && services.some(s => !!s.setContent)) {

--- a/src/createManager.js
+++ b/src/createManager.js
@@ -321,9 +321,12 @@ export class AdManager extends EventEmitter {
             if (!instance.notInViewport()) {
                 instance.defineSlot();
                 const adSlot = instance.adSlot;
-                const services = adSlot.getServices();
-                if (!hasPubAdsService) {
-                    hasPubAdsService = services.filter(service => !!service.enableAsyncRendering).length > 0;
+
+                if (adSlot && adSlot.hasOwnProperty("getServices")) {
+                    const services = adSlot.getServices();
+                    if (!hasPubAdsService) {
+                        hasPubAdsService = services.filter(service => !!service.enableAsyncRendering).length > 0;
+                    }
                 }
             }
         });

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -219,7 +219,10 @@ describe("Bling", () => {
     it("handles empty adSlot on clear", () => {
         const instance = new Bling();
         instance._adSlot = {};
-        instance.clear();
+
+        expect(() => {
+            instance.clear();
+        }).to.not.throw("adSlot.getServices is not a function");
     });
 
     it("calls getServices on adSlot on clear", () => {

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -216,6 +216,20 @@ describe("Bling", () => {
         clear.restore();
     });
 
+    it("handles empty adSlot on clear", () => {
+        const instance = new Bling();
+        instance._adSlot = {};
+        instance.clear();
+    });
+
+    it("calls getServices on adSlot on clear", () => {
+        const instance = new Bling();
+        const adSlot = sinon.mock({getServices: () => {}});
+        adSlot.expects("getServices").once();
+        instance._adSlot = adSlot;
+        instance.clear();
+    });
+
     it("updates correlator", () => {
         const updateCorrelator = sinon.stub(Bling._adManager, "updateCorrelator");
 


### PR DESCRIPTION
#### Issue
When using an ad blocker `adSlot` can become an empty object which causes the call to `adSlot.getServices` to produce the error: "getServices is not a function".

#### Solution
By adding the check `adSlot.hasOwnProperty("getServices")` we can ensure that the `adSlot` object has the correct function before attempting to call it.