### PR TITLE
Fixing the check for gptReady

### DIFF
--- a/src/createManager.js
+++ b/src/createManager.js
@@ -443,7 +443,7 @@ export class AdManager extends EventEmitter {
                     reject(new Error("window.googletag is not available"));
                 }
             };
-            if (window.googletag) {
+            if (window.googletag && googletag.apiReady) {
                 onLoad();
             } else {
                 const script = document.createElement("script");


### PR DESCRIPTION
Following the instructions suggested in https://developers.google.com/doubleclick-gpt/common_implementation_mistakes looking for apiReady before calling onload.