### PR TITLE
(feat) add bundlesize to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lib"
   ],
   "dependencies": {
+    "bundlesize": "^0.14.4",
     "debounce": "^1.0.0",
     "deep-equal": "^1.0.1",
     "eventemitter3": "^2.0.2",
@@ -95,6 +96,7 @@
     "build": "npm run clean && npm run compile",
     "build:umd": "NODE_ENV=development webpack src/index.js dist/react-gpt.js",
     "build:umd:min": "NODE_ENV=production webpack -p src/index.js dist/react-gpt.min.js",
+    "bundlesize": "npm run build:umd:min && bundlesize",
     "clean": "rimraf lib coverage",
     "compile": "babel src --out-dir lib",
     "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples/apps --inline",
@@ -109,5 +111,11 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
-  }
+  },
+  "bundlesize": [
+    {
+      "path": "./dist/react-gpt.min.js",
+      "maxSize": "8.5 kB"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
     "webpack-dev-middleware": "^1.5.1",
     "webpack-dev-server": "^1.14.1"
   },
+  "peerDepencencies": {
+      "prop-types": "^15.5.10",
+      "react": "^15.0.1",
+      "react-dom": "^15.0.1"
+  },
   "scripts": {
     "commit": "git-cz",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",


### PR DESCRIPTION
Addresses #46 to expose library size with npm script. 
Also updates peer dependencies so the project announces distribution size to https://bundlephobia.com/result?p=react-gpt  