### PR TITLE
(refactor) upgrade to react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,7 @@
     "bugs": {
         "url": "https://github.com/nfl/react-gpt/issues"
     },
-    "files": [
-        "*.md",
-        "docs",
-        "es",
-        "src",
-        "dist",
-        "lib"
-    ],
+    "files": ["*.md", "docs", "es", "src", "dist", "lib"],
     "dependencies": {
         "deep-equal": "^1.0.1",
         "eventemitter3": "^2.0.2",
@@ -61,11 +54,11 @@
         "core-js": "^2.2.2",
         "cz-conventional-changelog": "^1.1.6",
         "eslint": "4.7.0",
-        "eslint-config-prettier": "^2.5.0",
-        "eslint-plugin-prettier": "^2.2.0",
         "eslint-config-nfl": "12.0.0",
+        "eslint-config-prettier": "^2.5.0",
         "eslint-plugin-import": "2.7.0",
         "eslint-plugin-mocha": "4.11.0",
+        "eslint-plugin-prettier": "^2.2.0",
         "eslint-plugin-react": "7.3.0",
         "express": "^4.13.4",
         "history": "^4.3.0",
@@ -85,9 +78,10 @@
         "prop-types": "^15.5.10",
         "querystring": "^0.2.0",
         "radium": "^0.18.1",
-        "react": "^15.0.1",
+        "react": "^16.0.0",
         "react-addons-test-utils": "^15.0.1",
-        "react-dom": "^15.0.1",
+        "react-dom": "^16.0.0",
+        "react-test-renderer": "^16.0.0",
         "rimraf": "^2.5.2",
         "serve-static": "^1.10.2",
         "sinon": "^1.17.2",
@@ -98,24 +92,29 @@
     },
     "peerDependencies": {
         "prop-types": "^15.5.10",
-        "react": "^15.0.1",
-        "react-dom": "^15.0.1"
+        "react": "^15.0.1 || ^16.0.0",
+        "react-dom": "^15.0.1 || ^16.0.0"
     },
     "scripts": {
         "commit": "git-cz",
         "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
         "build": "npm run clean && npm run compile",
         "build:es": "BABEL_ENV=es babel --copy-files ./src -d es",
-        "build:umd": "NODE_ENV=development webpack src/index.js dist/react-gpt.js",
-        "build:umd:min": "NODE_ENV=production webpack -p src/index.js dist/react-gpt.min.js",
+        "build:umd":
+            "NODE_ENV=development webpack src/index.js dist/react-gpt.js",
+        "build:umd:min":
+            "NODE_ENV=production webpack -p src/index.js dist/react-gpt.min.js",
         "bundlesize": "npm run build:umd:min && bundlesize",
         "clean": "rimraf lib coverage dist lib es",
         "compile": "babel src --out-dir lib",
-        "examples": "webpack-dev-server --config examples/webpack.config.js --content-base examples/apps --inline",
+        "examples":
+            "webpack-dev-server --config examples/webpack.config.js --content-base examples/apps --inline",
         "lint": "eslint --fix src test examples",
-        "start": "npm run build && env BABEL_ENV=examples node examples/server/index.js",
+        "start":
+            "npm run build && env BABEL_ENV=examples node examples/server/index.js",
         "pretest": "npm run build",
-        "prepublish": "npm run build && npm run build:es && npm run build:umd && npm run build:umd:min",
+        "prepublish":
+            "npm run build && npm run build:es && npm run build:umd && npm run build:umd:min",
         "test": "npm run lint && karma start",
         "update-apilist": "node ./scripts/updateAPIList.js"
     },

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -2,6 +2,7 @@
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 import ReactTestUtils from "react-dom/test-utils";
+import ShallowRenderer from "react-test-renderer/shallow";
 import Bling from "../src/Bling";
 import Events from "../src/Events";
 import {pubadsAPI, APIToCallBeforeServiceEnabled} from "../src/createManager";
@@ -25,15 +26,18 @@ describe("Bling", () => {
     });
 
     it("throws when either slotSize or sizeMapping is missing", () => {
-        expect(() => {
-            ReactTestUtils.renderIntoDocument(
-                <Bling adUnitPath="/4595/nfl.test.open" />
-            );
-        }).to.throw("Either 'slotSize' or 'sizeMapping' prop needs to be set.");
+        const renderBling = () => {
+            const renderer = new ShallowRenderer();
+            renderer.render(<Bling adUnitPath="/4595/nfl.test.open" />);
+        };
+
+        expect(renderBling).to.throw(
+            "Either 'slotSize' or 'sizeMapping' prop needs to be set."
+        );
     });
 
     it("initially renders empty div with style", () => {
-        const renderer = ReactTestUtils.createRenderer();
+        const renderer = new ShallowRenderer();
         renderer.render(
             <Bling adUnitPath="/4595/nfl.test.open" slotSize={[728, 90]} />
         );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,14 +1701,6 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-create-react-class@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2408,6 +2400,18 @@ faye-websocket@~0.11.0:
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
   dependencies:
     websocket-driver ">=0.5.1"
+
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
 
 fbjs@^0.8.9:
   version "0.8.14"
@@ -4414,6 +4418,14 @@ prop-types@^15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 proxy-addr@~1.1.4:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
@@ -4518,24 +4530,30 @@ react-addons-test-utils@^15.0.1:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
 
-react-dom@^15.0.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+"react-dom@^15.0.1 || ^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react@^15.0.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+react-test-renderer@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0.tgz#9fe7b8308f2f71f29fc356d4102086f131c9cb15"
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+
+"react@^15.0.1 || ^16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
+  dependencies:
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Goal: 

Update to allow React 16 as a `peerDependency`.

## Changes:

1. react 16 as a `peerDependency`
2. react 16 as a `devDependency` with all tests passing. 
3. tests should still pass with react 15 
4. using `react-test-renderer` for `ShallowRenderer` tests now

## Notes

1. Replaces #57 
2. To test against React 15, first update `package.json: devDependency`, reminstall node_modules, then `npm run test`
```
// 1. manually update "package.json: devDependency" 
"react": "^15.0.1",
"react-dom": "^15.0.1",
```