### PR TITLE
Don't call configureSlot on update if this._adSlot is not defined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "react-gpt",
-    "version": "1.1.1",
+    "name": "@poki/react-gpt",
+    "version": "1.1.2",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "exenv": "^1.2.2",
         "hoist-non-react-statics": "^1.0.5",
         "invariant": "^2.2.2",
-        "prettier": "^1.7.0",
         "throttle-debounce": "^1.0.1"
     },
     "devDependencies": {
@@ -75,6 +74,7 @@
         "karma-webpack": "^1.7.0",
         "mocha": "^3.1.2",
         "phantom": "^2.0.4",
+        "prettier": "^1.7.0",
         "prop-types": "^15.5.10",
         "querystring": "^0.2.0",
         "radium": "^0.18.1",

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -425,7 +425,7 @@ class Bling extends Component {
             !propsEqual(refreshableProps.props, refreshableProps.nextProps);
         // console.log(`shouldRefresh: ${shouldRefresh}, shouldRender: ${shouldRender}, isScriptLoaded: ${isScriptLoaded}, syncCorrelator: ${Bling._adManager._syncCorrelator}`);
 
-        if (shouldRefresh) {
+        if (shouldRefresh && this._adSlot) {
             this.configureSlot(this._adSlot, nextProps);
         }
 


### PR DESCRIPTION
We are having an issue using this library only in chrome + incognito mode. I suspect that other adblockers might cause the same/similar issues.

Basically, what happens is, when ad ad slot should be updated and `this._adSlot` has not been created (cause the script was not loaded), `this.configureSlot` throws an error cause `adSlot` is undefined.

I am not 100% sure if this is the most full-featured fix, but it at least fixes the issues we are having.