### PR TITLE
(fix) remove export of createManagerTest from index

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "bundlesize": [
         {
             "path": "./dist/react-gpt.min.js",
-            "maxSize": "10.5 kB"
+            "maxSize": "8.5 kB"
         }
     ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
 export {default as Bling} from "./Bling";
 export {default as Events} from "./Events";
-export {createManagerTest} from "./utils/createManagerTest";


### PR DESCRIPTION
Fixes #29 

*Change Log* 
(fix) remove an unnecessary import of `createManagerTest.js` in `index.js` - fixes unnecessary bundling of `mockGPT` and `createManagerTest` in production bundle. 

*Test Plan*
1. `npm run build`
2. Review `dist/react-gpt.js` to ensure `createManagerTest` and `mockGPT` are not imported. 
3. `npm run test` run tests to make sure everything still works 