### PR TITLE
(release) 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.1.2"></a>
+
+## [1.1.2](https://github.com/nfl/react-gpt/compare/v1.1.1...v1.1.2) (2018-01-04)
+
+### Bug Fixes
+
+* Removed test util dependencies from distribution ([27187e0](https://github.com/nfl/react-gpt/commit/27187e0))
+
 <a name="1.1.1"></a>
 
 ## [1.1.1](https://github.com/nfl/react-gpt/compare/v1.0.1...v1.1.1) (2017-11-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,21 @@
-<a name="1.1.2"></a>
+<a name="2.0.0"></a>
 
-## [1.1.2](https://github.com/nfl/react-gpt/compare/v1.1.1...v1.1.2) (2018-01-04)
+## [2.0.0](https://github.com/nfl/react-gpt/compare/v1.1.1...v2.0.0) (2018-01-04)
 
 ### Bug Fixes
 
 * Removed test util dependencies from distribution ([27187e0](https://github.com/nfl/react-gpt/commit/27187e0))
+
+### Migration notes
+
+**< 2.0.0** you may have imported `createManagerTest` like this:
+```
+import {createManagerTest} from "react-gpt";
+```
+**>= 2.0.0** you now need to import `createManagerTest` like this:
+```
+import {createManagerTest} from "react-gpt/es/utils/createManagerTest";
+```
 
 <a name="1.1.1"></a>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-gpt",
-    "version": "1.1.2",
+    "version": "2.0.0",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-gpt",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "description": "A react display ad component using Google Publisher Tag",
     "main": "lib/index.js",
     "jsnext:main": "es/index.js",


### PR DESCRIPTION
Contains 
* version bump to 2.0.0
* changelog

### Bug Fixes

## [2.0.0](https://github.com/nfl/react-gpt/compare/v1.1.1...v2.0.0) (2018-01-04)

### Bug Fixes

* Removed test util dependencies from distribution ([27187e0](https://github.com/nfl/react-gpt/commit/27187e0))

### Migration notes

**< 2.0.0** you may have imported `createManagerTest` like this:
```
import {createManagerTest} from "react-gpt";
```
**>= 2.0.0** you now need to import `createManagerTest` like this:
```
import {createManagerTest} from "react-gpt/es/utils/createManagerTest";
```
