### PR TITLE
Don't setState on an unmounted ad.

### DIFF
--- a/src/Bling.js
+++ b/src/Bling.js
@@ -477,13 +477,20 @@ class Bling extends Component {
         }
     }
 
+    isAdMounted() {
+        return Bling._adManager.getMountedInstances().indexOf(this) !== -1;
+    }
+
     onScriptLoaded() {
         const { onScriptLoaded } = this.props;
 
         if (this.getRenderWhenViewable()) {
             this.foldCheck();
         }
-        this.setState({ scriptLoaded: true }, onScriptLoaded); // eslint-disable-line react/no-did-mount-set-state
+
+        if (this.isAdMounted()) {
+            this.setState({ scriptLoaded: true }, onScriptLoaded); // eslint-disable-line react/no-did-mount-set-state
+        }
     }
 
     onScriptError(err) {

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -742,6 +742,21 @@ describe("Bling", () => {
         ReactTestUtils.renderIntoDocument(<Wrapper />);
     });
 
+    it("does not call props.onSlotLoaded if it has been unmounted", () => {
+        const onScriptLoaded = sinon.stub();
+        const instance = ReactTestUtils.renderIntoDocument(
+            <Bling
+                adUnitPath="/4595/nfl.test.open"
+                slotSize={[300, 250]}
+                onScriptLoaded={onScriptLoaded}
+            />
+        );
+        onScriptLoaded.reset();
+        instance.componentWillUnmount();
+        instance.onScriptLoaded();
+        expect(onScriptLoaded.called).to.be.false;
+    });
+
     it("removes itself from registry when unmounted", () => {
         const instance = ReactTestUtils.renderIntoDocument(
             <Bling adUnitPath="/4595/nfl.test.open" slotSize={[300, 250]} />


### PR DESCRIPTION
Calling `this.setState` on an unmounted component throws exceptions in React. Since `Bling._adManager` is already tracking which ads are mounted, this uses that registry to check whether to call `setState` in `onScriptLoaded`.