### PR TITLE
Enable non-personalized Ads to support GDPR compliance 

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "bundlesize": [
         {
             "path": "./dist/react-gpt.min.js",
-            "maxSize": "8.5 kB"
+            "maxSize": "8.53 kB"
         }
     ]
 }

--- a/src/Bling.js
+++ b/src/Bling.js
@@ -394,11 +394,6 @@ class Bling extends Component {
             : Bling._config.viewableThreshold;
     }
 
-    componentWillMount() {
-        const {npa} = this.props;
-        this.handleSetNpaFlag(npa);
-    }
-
     componentDidMount() {
         Bling._adManager.addInstance(this);
         Bling._adManager
@@ -410,7 +405,6 @@ class Bling extends Component {
     componentWillReceiveProps(nextProps) {
         const {propsEqual} = Bling._config;
         const {sizeMapping} = this.props;
-        const {npa} = nextProps;
 
         if (
             (nextProps.sizeMapping || sizeMapping) &&
@@ -418,8 +412,6 @@ class Bling extends Component {
         ) {
             Bling._adManager.removeMQListener(this, nextProps);
         }
-
-        this.handleSetNpaFlag(npa);
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -626,9 +618,11 @@ class Bling extends Component {
     }
 
     defineSlot() {
-        const { adUnitPath, outOfPage } = this.props;
+        const { adUnitPath, outOfPage, npa } = this.props;
         const divId = this._divId;
         const slotSize = this.getSlotSize();
+
+        this.handleSetNpaFlag(npa);
 
         if (!this._adSlot) {
             if (outOfPage) {

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -163,6 +163,40 @@ describe("Bling", () => {
         );
     });
 
+    it("call pubads API to set non-personalized Ads when npa prop is set", () => {
+        const renderer = new ShallowRenderer();
+        const spy = sinon.stub(Bling._adManager, "pubadsProxy");
+        const expectedParam = {
+            method: "setRequestNonPersonalizedAds",
+            args: [1],
+            resolve: null,
+            reject: null
+        };
+
+        renderer.render(
+            <Bling
+                adUnitPath="/4595/nfl.test.open"
+                npa={true}
+                slotSize={["fluid"]}
+            />
+        );
+
+        expect(spy.calledWith(expectedParam)).to.be.true;
+
+        renderer.unmount();
+        renderer.render(
+            <Bling
+                adUnitPath="/4595/nfl.test.open"
+                npa={false}
+                slotSize={["fluid"]}
+            />
+        );
+
+        expectedParam.args = [0];
+        expect(spy.calledWith(expectedParam)).to.be.true;
+        spy.restore();
+    });
+
     it("fires once event", done => {
         const events = Object.keys(Events).map(key => Events[key]);
 

--- a/test/Bling.spec.js
+++ b/test/Bling.spec.js
@@ -163,17 +163,28 @@ describe("Bling", () => {
         );
     });
 
-    it("call pubads API to set non-personalized Ads when npa prop is set", () => {
-        const renderer = new ShallowRenderer();
+    it("call pubads API to set non-personalized Ads when npa prop is set", done => {
         const spy = sinon.stub(Bling._adManager, "pubadsProxy");
-        const expectedParam = {
+        const expectedParamTrue = {
             method: "setRequestNonPersonalizedAds",
             args: [1],
             resolve: null,
             reject: null
         };
+        const expectedParamFalse = {
+            ...expectedParamTrue,
+            args: [0]
+        };
 
-        renderer.render(
+        Bling.once(Events.RENDER, () => {
+            expect(spy.calledWith(expectedParamTrue)).to.be.true;
+            expect(spy.calledWith(expectedParamFalse)).to.be.true;
+            spy.restore();
+            done();
+        });
+
+        // Render once to test with non-personalized ads
+        ReactTestUtils.renderIntoDocument(
             <Bling
                 adUnitPath="/4595/nfl.test.open"
                 npa={true}
@@ -181,20 +192,14 @@ describe("Bling", () => {
             />
         );
 
-        expect(spy.calledWith(expectedParam)).to.be.true;
-
-        renderer.unmount();
-        renderer.render(
+        // Render a second time to test re-enable personalized ads
+        ReactTestUtils.renderIntoDocument(
             <Bling
                 adUnitPath="/4595/nfl.test.open"
                 npa={false}
                 slotSize={["fluid"]}
             />
         );
-
-        expectedParam.args = [0];
-        expect(spy.calledWith(expectedParam)).to.be.true;
-        spy.restore();
     });
 
     it("fires once event", done => {


### PR DESCRIPTION
According to EU regulations, it is mandatory to enable users to opt-out to tracking cookies
GPT allows us to respect this law using the `npa` flag on Ads.
