### PR TITLE
Fix issue with Bling when there is no ad slot

### DIFF
--- a/src/Bling.js
+++ b/src/Bling.js
@@ -440,10 +440,9 @@ class Bling extends Component {
             this.props,
             nextProps
         );
-        const shouldRender = !propsEqual(
-            reRenderProps.props,
-            reRenderProps.nextProps
-        );
+        const shouldRender =
+            !this._adSlot ||
+            !propsEqual(reRenderProps.props, reRenderProps.nextProps);
         const shouldRefresh =
             !shouldRender &&
             !propsEqual(refreshableProps.props, refreshableProps.nextProps);


### PR DESCRIPTION
Fixes an issue where `setAttributes` can be called when there is no ad slot